### PR TITLE
Remove data filtering from GithubGrabber

### DIFF
--- a/shuffleboard/cli.py
+++ b/shuffleboard/cli.py
@@ -11,19 +11,14 @@ repos = ['shuffleboard']
 @click.command()
 def main(args=None):
 
-    gh = github_api.GithubGrabber(repos=repos, http_client=requests)
-
-    issues = gh.get_issues()
-    for (repo, issues_list) in issues.items():
-        print("repo")
-        [print(vars(i)) for i in issues_list]
+    gh = github_api.GithubGrabber(http_client=requests)
 
     events = gh.get_events()
     for (repo, typed_events) in events.items():
         print(repo)
         for (typed_event_name, event_list) in typed_events.items():
             print(typed_event_name)
-            [print(vars(e)) for e in event_list]
+            [print(list(e.items())) for e in event_list]
 
 
 if __name__ == "__main__":

--- a/shuffleboard/github_api.py
+++ b/shuffleboard/github_api.py
@@ -1,154 +1,40 @@
 # -*- coding: utf-8 -*-
 
-import re
-import warnings
-
-
-# Data types for use within Shuffleboard
-# TODO these should be explicitly listed out
-
-
-class Event:
-    def __init__(self, attributes):
-        for (key, value) in attributes.items():
-            setattr(self, key, value)
-
-
-class IssueEvent(Event):
-    def __init__(self, attributes):
-        super().__init__(attributes)
-        self.action = attributes['action']
-
-
-class Issue:
-    def __init__(self, attributes):
-        for (key, value) in attributes.items():
-            setattr(self, key, value)
-
-# TODO Milestone
-
-# TODO PullRequest
-
-# TODO Contributor
-
-
-# Dispatchers to manage data transformation between Github and Shuffleboard
-
-class EventDispatch:
-    def __init__(self):
-        self.dispatcher = {
-            "id": lambda x: x,
-            "type": lambda x: x,
-            "actor": lambda x: x['login'] if x and 'login' in x else None,
-            "repo": lambda x: x['name'] if x and 'name' in x else None,
-            "created_at": lambda x: x,
-        }
-
-
-class IssueDispatch:
-    def __init__(self):
-        self.dispatcher = {
-            "comments_count": lambda x: x,
-            "body": lambda x: x,
-            "closed_at": lambda x: x,
-            "created_at": lambda x: x,
-            "number": lambda x: x,
-            "state": lambda x: x,
-            "updated_at": lambda x: x,
-            "assignee": lambda x: x['login'] if x and 'login' in x else None,
-            "closed_by": lambda x: x['login'] if x and 'login' in x else None,
-            "milestone": lambda x: x['title'] if x and 'title' in x else None,
-            "pull_request": lambda x: x['number'] if x and 'number' in x
-            else None,
-            "user": lambda x: x['login'] if x and 'login' in x else None
-        }
-
 
 # Class to handle getting Github data at the repository level
 
 class GithubGrabber:
     def __init__(self,
-                 repos=[],
-                 dispatchers=None,
+                 page=100,
                  owner='BonnyCI',
                  http_client=None,
                  gh_api_base='https://api.github.com'):
 
         self.owner = owner
-        self.repos = repos
         self.gh_api_base = gh_api_base
-
         self.http_client = http_client
-
-        if dispatchers is None:
-            self.dispatchers = self._build_dispatchers()
-        else:
-            self.dispatchers = dispatchers
-
-    def _build_dispatchers(self):
-        return {
-            "issue": IssueDispatch().dispatcher,
-            "event": EventDispatch().dispatcher,
-        }
+        self.page = 100
 
     def _get(self, url):
         response = self.http_client.get(url)
         return response.json()
 
-    def extract_fields(self, dispatcher_type, data):
-        if dispatcher_type in self.dispatchers:
-            dispatcher = self.dispatchers[dispatcher_type]
-        else:
-            warnings.warn("dispatcher_type %s not found" % dispatcher_type)
-            return []
-
-        attributes = {}
-        for a in filter(lambda a: a in dispatcher, data.keys()):
-            attributes[a] = dispatcher[a](data[a])
-        return attributes
-
-    def get_issues(self):
-        issues = {}
-        for repo in self.repos:
-            repo_endpoint = '/repos/%s/%s/issues' % (self.owner, repo)
-            issues_decoded = self._get(self.gh_api_base + repo_endpoint +
-                                       '?per_page=100')
-
-            if repo not in issues:
-                issues[repo] = []
-
-            for i in issues_decoded:
-                issue = Issue(self.extract_fields('issue', i))
-                issues[repo].append(issue)
-        return issues
-
+    # get events and group by type
     def get_events(self):
         events_endpoint = '/users/%s/events' % (self.owner)
         events_decoded = self._get(self.gh_api_base + events_endpoint +
-                                   '?per_page=100')
+                                   '?per_page=%s' % self.page)
         events = {}
         for e in events_decoded:
-            attributes = self.extract_fields('event', e)
+            repo = e['repo']['name']
+            type = e['type']
 
-            if re.match("Issue", e['type']):
-                attributes['action'] = e['payload']['action']
-                attributes['issue'] = e['payload']['issue']['number']
-                attributes['instance'] = Issue(self.extract_fields(
-                    'issue', e['payload']['issue']))
-                event = IssueEvent(attributes)
+            if repo not in events:
+                events[repo] = {}
+
+            if type not in events[repo]:
+                events[repo][type] = [e]
             else:
-                # it's an event type we haven't account for yet
-                #  get the payload fields so we can stub it out
-                attributes['payload'] = list(e['payload'].keys())
-                event = Event(attributes)
-
-            if event.repo not in events:
-                events[event.repo] = {}
-
-            if event.type not in events[event.repo]:
-                events[event.repo][event.type] = [event]
-            else:
-                events[event.repo][event.type].append(event)
+                events[repo][type].append(e)
 
         return events
-

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -20,60 +20,14 @@ from shuffleboard import github_api
 
 
 class MockGithubClient:
-    def __init__(self, key=42):
-        self.issue_populated = {
-            "comments_count": 1,
-            "body": "issue body",
-            "closed_at": "2016-12-15",
-            "created_at": "2016-12-15",
-            "number": key,
-            "state": "open",
-            "updated_at": "2016-12-15",
-            "assignee": {"login": "foobear"},
-            "closed_by": {"login": "foobear"},
-            "milestone": {"title": "do it!"},
-            "pull_request": {"number": 1},
-            "user": {"login": "foobear"},
-            "extra1": "HELO",
-            "extra2": "ACK"
-        }
-
-        self.issue_minimal = {
-            "comments_count": None,
-            "body": None,
-            "closed_at": None,
-            "created_at": "2016-12-15",
-            "number": key,
-            "state": "open",
-            "updated_at": "2016-12-15",
-            "assignee": None,
-            "closed_by": None,
-            "milestone": None,
-            "pull_request": None,
-            "user": {"login": "foobear"},
-            "extra1": None,
-            "extra2": None
-        }
-
+    def __init__(self, key=42, repo="repo"):
         self.event = {
             "id": key,
             "type": "Caturday",
             "actor": {"login": "foobear"},
-            "repo": {"name": "repo"},
+            "repo": {"name": repo},
             "created_at": '2016-12-15',
             "payload": {"cha":"ching"}
-        }
-
-        self.issue_event = {
-            "id": key,
-            "type": "IssueEvent",
-            "actor": {"login": "foobear"},
-            "repo": {"name": "repo"},
-            "created_at": '2016-12-15',
-            "payload": {
-                "action": "pwned",
-                "issue": {**self.issue_minimal}
-            }
         }
 
 
@@ -85,13 +39,6 @@ class TestGithubGrabber(unittest.TestCase):
     def tearDown(self):
         pass
 
-    # utility function to list the attributes in an object
-    def _list_attributes(self, o):
-        attributes = []
-        for a in filter(lambda a: not a.startswith('__'), dir(o)):
-            attributes.append(a)
-        return sorted(attributes)
-
     def _get(self, mock_data):
         with patch('requests.Request') as mock:
             http_fake = mock.return_value
@@ -99,212 +46,31 @@ class TestGithubGrabber(unittest.TestCase):
                                               {"json": lambda: mock_data})
             return http_fake
 
-    def test_extract_attrs(self):
-        # create a GithubGrabber instance with a custom test dispatcher
-        fake_dispatcher = {"bar": lambda x: x}
-        gh = github_api.GithubGrabber(dispatchers={
-                                          "fake_dispatcher": fake_dispatcher},
-                                      http_client=None)
-        result = gh.extract_fields(dispatcher_type="fake_dispatcher",
-                                   data={"bar": "baz"})
-
-        assert result == {"bar": "baz"}
-
-    def test_extract_attrs_bad_dispatcher_type(self):
-
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-
-            # create a GithubGrabber instance with no dispatchers
-            gh = github_api.GithubGrabber(dispatchers={}, http_client=None)
-            result = gh.extract_fields(dispatcher_type="bad", data=None)
-            # check that we get the expected empty list back
-            assert result == []
-
-            # Check that a warning was issued
-            assert len(w) == 1
-            assert issubclass(w[-1].category, UserWarning)
-            assert "dispatcher_type" in str(w[-1].message)
-
-    def test_get_issues_one(self):
-        http_fake = self._get([MockGithubClient().issue_populated])
-
-        grabber = github_api.GithubGrabber(http_client=http_fake, repos=[
-            "foo"])
-        issues = grabber.get_issues()
-        repo_issues = issues["foo"]
-        test_issue = repo_issues[0]
-
-        expected = {
-            "comments_count": 1,
-            "body": "issue body",
-            "closed_at": "2016-12-15",
-            "created_at": "2016-12-15",
-            "number": 42,
-            "state": "open",
-            "updated_at": "2016-12-15",
-            "assignee": "foobear",
-            "closed_by": "foobear",
-            "milestone": "do it!",
-            "pull_request": 1,
-            "user": "foobear"
-        }
-
-        expected_attr = sorted(expected.keys())
-        for a in expected_attr:
-            # check that we didn't drop any fields
-            assert hasattr(test_issue, a)
-            # check that the values we expected got set
-            assert expected[a] == getattr(test_issue, a)
-
-        # check that we didn't pick up any extra values
-        assert expected_attr == self._list_attributes(test_issue)
-
-    def test_get_issues_populated(self):
-        http_fake = self._get([MockGithubClient().issue_populated,
-                               MockGithubClient(key=1).issue_populated,
-                               MockGithubClient(key=2).issue_populated])
-        grabber = github_api.GithubGrabber(http_client=http_fake, repos=["foo"])
-        issues = grabber.get_issues()
-        repo_issues = issues["foo"]
-        test_issue = repo_issues[0]
-
-        expected = {
-            "comments_count": 1,
-            "body": "issue body",
-            "closed_at": "2016-12-15",
-            "created_at": "2016-12-15",
-            "number": 42,
-            "state": "open",
-            "updated_at": "2016-12-15",
-            "assignee": "foobear",
-            "closed_by": "foobear",
-            "milestone": "do it!",
-            "pull_request": 1,
-            "user": "foobear"
-        }
-
-        expected_attr = sorted(expected.keys())
-        for a in expected_attr:
-            # check that we didn't drop any fields
-            assert hasattr(test_issue, a)
-            # check that the values we expected got set
-            assert expected[a] == getattr(test_issue, a)
-
-        # check that we didn't pick up any extra values
-        assert expected_attr == self._list_attributes(test_issue)
-
-    def test_get_issues_minimal(self):
-        http_fake = self._get([MockGithubClient().issue_minimal,
-                               MockGithubClient(key=1).issue_minimal,
-                               MockGithubClient(key=2).issue_minimal])
-        grabber = github_api.GithubGrabber(http_client=http_fake, repos=[
-            "foo"])
-        issues = grabber.get_issues()
-        repo_issues = issues["foo"]
-        test_issue = repo_issues[0]
-
-        expected = {
-            "comments_count": None,
-            "body": None,
-            "closed_at": None,
-            "created_at": "2016-12-15",
-            "number": 42,
-            "state": "open",
-            "updated_at": "2016-12-15",
-            "assignee": None,
-            "closed_by": None,
-            "milestone": None,
-            "pull_request": None,
-            "user": "foobear"
-        }
-
-        expected_attr = sorted(expected.keys())
-        for a in expected_attr:
-            # check that we didn't drop any fields
-            assert hasattr(test_issue, a)
-            # check that the values we expected got set
-            assert expected[a] == getattr(test_issue, a)
-
-        # check that we didn't pick up any extra values
-        assert expected_attr == self._list_attributes(test_issue)
-
-    def test_get_issues_no_repos(self):
-        grabber = github_api.GithubGrabber(http_client=None)
-        issues = grabber.get_issues()
-        assert issues == {}
-
-    def test_get_issues_empty_set(self):
-        http_fake = self._get([])
-        grabber = github_api.GithubGrabber(http_client=http_fake, repos=[
-            "foo"])
-        issues = grabber.get_issues()
-        assert issues["foo"] == []
-
-    def test_get_events_one_issue_event(self):
-        http_fake = self._get([MockGithubClient().issue_event])
+    def test_get_events(self):
+        expected = MockGithubClient().event
+        http_fake = self._get([expected])
         grabber = github_api.GithubGrabber(http_client=http_fake)
         events = grabber.get_events()
-        repo_events = events["repo"]
-        test_event = repo_events['IssueEvent'][0]
 
-        expected = {
-            "id": 42,
-            "type": "IssueEvent",
-            "actor": "foobear",
-            "repo": "repo",
-            "created_at": '2016-12-15',
-            "instance": github_api.Issue(MockGithubClient().issue_minimal),
-            "issue": 42,
-            "action": "pwned"
-        }
+        # check that our return structure is keyed on repo and event type
+        self.assertTrue('repo' in events,
+                        msg="%s not in events data" % expected['repo']['name'])
+        self.assertTrue('Caturday' in events['repo'],
+                        msg="%s not in events data" % expected['type'])
+        self.assertEquals(len(events['repo']['Caturday']), 1)
 
-        expected_attr = sorted(expected.keys())
-        for a in expected_attr:
+        got = events['repo']['Caturday'][0]
+
+        for e in expected:
             # check that we didn't drop any fields
-            self.assertTrue(hasattr(test_event, a), msg="missing %s" % a)
+            self.assertTrue(e in got, msg="missing %s" % e)
             # check that the values we expected got set
-            got_attr = getattr(test_event, a)
-            if a == "instance":
-                self.assertTrue(expected[a].__eq__(got_attr),
-                                msg="instances don't match")
-            else:
-                self.assertEqual(expected[a], got_attr, msg= "%s value "
-                                 "didn't match: expected %s, got %s" %
-                                (a, expected_attr, got_attr))
-
-        # check that we didn't pick up any extra values
-        assert expected_attr == self._list_attributes(test_event)
-
-    def test_get_events_one(self):
-        http_fake = self._get([MockGithubClient().event])
-        grabber = github_api.GithubGrabber(http_client=http_fake)
-        events = grabber.get_events()
-        repo_events = events["repo"]
-        test_event = repo_events['Caturday'][0]
-
-        expected = {
-            "id": 42,
-            "type": "Caturday",
-            "actor": "foobear",
-            "repo": "repo",
-            "created_at": '2016-12-15',
-            "payload": ["cha"]
-        }
-
-        expected_attr = sorted(expected.keys())
-        for a in expected_attr:
-            # check that we didn't drop any fields
-            self.assertTrue(hasattr(test_event, a), msg="missing %s" % a)
-            # check that the values we expected got set
-            got_attr = getattr(test_event, a)
-            self.assertEqual(expected[a], got_attr, msg= "%s value "
+            self.assertEqual(expected[e], got[e], msg= "%s value "
                              "didn't match: expected %s, got %s" %
-                            (a, expected_attr, got_attr))
+                            (e, expected[e], got[e]))
 
         # check that we didn't pick up any extra values
-        assert expected_attr == self._list_attributes(test_event)
+        self.assertEqual(sorted(expected.keys()), sorted(got.keys()), msg="found extra values")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This was fine for testing and verifying the data as a fun python
experiment, but it's pretty pointless. This transformation should
be happening on the reporting end when the data analysis happens.
Right now we should just be grabbing all the dataz.

Closes Issue #45

Signed-off-by: Augustina Ragwitz <augustina.ragwitz@ibm.com>